### PR TITLE
Add MongoDB support

### DIFF
--- a/DataFlow.Core/DataFlow.Core.csproj
+++ b/DataFlow.Core/DataFlow.Core.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.22.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.8" />
   </ItemGroup>

--- a/DataFlow.Core/MongoDB/MongoReader.cs
+++ b/DataFlow.Core/MongoDB/MongoReader.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace DataFlow.Core.MongoDB;
+
+public class MongoReader
+{
+    private readonly string _connectionString;
+    private readonly string _databaseName;
+    private readonly string _collectionName;
+    private FilterDefinition<BsonDocument> _filter = FilterDefinition<BsonDocument>.Empty;
+    private SortDefinition<BsonDocument> _sort;
+    private int? _limit;
+    private int? _skip;
+    private ProjectionDefinition<BsonDocument> _projection;
+    private readonly List<string> _pipeline = new List<string>();
+
+    public MongoReader(string connectionString, string databaseName, string collectionName)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+            throw new ArgumentNullException(nameof(connectionString));
+        if (string.IsNullOrEmpty(databaseName))
+            throw new ArgumentNullException(nameof(databaseName));
+        if (string.IsNullOrEmpty(collectionName))
+            throw new ArgumentNullException(nameof(collectionName));
+            
+        _connectionString = connectionString;
+        _databaseName = databaseName;
+        _collectionName = collectionName;
+    }
+
+    public MongoReader Where(string field, object value)
+    {
+        _filter = Builders<BsonDocument>.Filter.Eq(field, BsonValue.Create(value));
+        return this;
+    }
+
+    public MongoReader Where(FilterDefinition<BsonDocument> filter)
+    {
+        _filter = filter;
+        return this;
+    }
+
+    public MongoReader WhereJson(string jsonFilter)
+    {
+        _filter = jsonFilter;
+        return this;
+    }
+
+    public MongoReader Sort(string field, bool ascending = true)
+    {
+        if (ascending)
+            _sort = Builders<BsonDocument>.Sort.Ascending(field);
+        else
+            _sort = Builders<BsonDocument>.Sort.Descending(field);
+        return this;
+    }
+
+    public MongoReader Limit(int limit)
+    {
+        _limit = limit;
+        return this;
+    }
+
+    public MongoReader Skip(int skip)
+    {
+        _skip = skip;
+        return this;
+    }
+
+    public MongoReader Project(params string[] fields)
+    {
+        var projectionBuilder = Builders<BsonDocument>.Projection;
+        ProjectionDefinition<BsonDocument> projection = null;
+
+        foreach (var field in fields)
+        {
+            projection = projection == null 
+                ? projectionBuilder.Include(field) 
+                : projection.Include(field);
+        }
+
+        if (projection != null && !fields.Contains("_id"))
+        {
+            projection = projection.Exclude("_id");
+        }
+
+        _projection = projection;
+        return this;
+    }
+
+    public MongoReader Aggregate(string pipelineStage)
+    {
+        _pipeline.Add(pipelineStage);
+        return this;
+    }
+
+    public IEnumerable<DataRow> Read()
+    {
+        var client = new MongoClient(_connectionString);
+        var database = client.GetDatabase(_databaseName);
+        var collection = database.GetCollection<BsonDocument>(_collectionName);
+
+        if (_pipeline.Any())
+        {
+            var pipelineDefinition = new BsonDocument[0];
+            foreach (var stage in _pipeline)
+            {
+                var stages = pipelineDefinition.ToList();
+                stages.Add(BsonDocument.Parse(stage));
+                pipelineDefinition = stages.ToArray();
+            }
+            
+            var cursor = collection.Aggregate<BsonDocument>(pipelineDefinition);
+            
+            foreach (var document in cursor.ToEnumerable())
+            {
+                yield return ConvertToDataRow(document);
+            }
+        }
+        else
+        {
+            var findOptions = new FindOptions<BsonDocument, BsonDocument>
+            {
+                Sort = _sort,
+                Limit = _limit,
+                Skip = _skip,
+                Projection = _projection
+            };
+
+            var cursor = collection.Find(_filter).Sort(_sort).Limit(_limit).Skip(_skip).Project<BsonDocument>(_projection);
+            
+            foreach (var document in cursor.ToEnumerable())
+            {
+                yield return ConvertToDataRow(document);
+            }
+        }
+    }
+
+    private DataRow ConvertToDataRow(BsonDocument document)
+    {
+        var row = new DataRow();
+        
+        foreach (var element in document.Elements)
+        {
+            row[element.Name] = ConvertBsonValue(element.Value);
+        }
+        
+        return row;
+    }
+
+    private object ConvertBsonValue(BsonValue value)
+    {
+        switch (value.BsonType)
+        {
+            case BsonType.Null:
+                return null;
+            case BsonType.String:
+                return value.AsString;
+            case BsonType.Int32:
+                return value.AsInt32;
+            case BsonType.Int64:
+                return value.AsInt64;
+            case BsonType.Double:
+                return value.AsDouble;
+            case BsonType.Decimal128:
+                return value.AsDecimal128.ToString();
+            case BsonType.Boolean:
+                return value.AsBoolean;
+            case BsonType.DateTime:
+                return value.ToUniversalTime();
+            case BsonType.ObjectId:
+                return value.AsObjectId.ToString();
+            case BsonType.Array:
+                return ConvertBsonArray(value.AsBsonArray);
+            case BsonType.Document:
+                return ConvertBsonDocument(value.AsBsonDocument);
+            default:
+                return value.ToString();
+        }
+    }
+
+    private object ConvertBsonArray(BsonArray array)
+    {
+        var list = new List<object>();
+        foreach (var item in array)
+        {
+            list.Add(ConvertBsonValue(item));
+        }
+        return list;
+    }
+
+    private object ConvertBsonDocument(BsonDocument document)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach (var element in document.Elements)
+        {
+            dict[element.Name] = ConvertBsonValue(element.Value);
+        }
+        return dict;
+    }
+}

--- a/DataFlow.Core/MongoDB/MongoWriter.cs
+++ b/DataFlow.Core/MongoDB/MongoWriter.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace DataFlow.Core.MongoDB;
+
+public class MongoWriter
+{
+    private readonly string _connectionString;
+    private readonly string _databaseName;
+    private readonly string _collectionName;
+    private bool _upsert = false;
+    private string _upsertKeyField = "_id";
+    private int _batchSize = 1000;
+    private bool _dropCollection = false;
+    private bool _createIndexes = false;
+    private List<string> _indexFields = new List<string>();
+    private InsertManyOptions _insertOptions;
+    private ReplaceOptions _replaceOptions;
+
+    public MongoWriter(string connectionString, string databaseName, string collectionName)
+    {
+        if (connectionString == null)
+            throw new ArgumentNullException(nameof(connectionString));
+        if (databaseName == null)
+            throw new ArgumentNullException(nameof(databaseName));
+        if (collectionName == null)
+            throw new ArgumentNullException(nameof(collectionName));
+        
+        this._connectionString = connectionString;
+        this._databaseName = databaseName;
+        this._collectionName = collectionName;
+        
+        _insertOptions = new InsertManyOptions();
+        _insertOptions.IsOrdered = false;
+        _replaceOptions = new ReplaceOptions();
+        _replaceOptions.IsUpsert = true;
+    }
+
+    public MongoWriter WithBatchSize(int batchSize)
+    {
+        _batchSize = batchSize;
+        return this;
+    }
+
+    public MongoWriter WithUpsert(string keyField = "_id")
+    {
+        _upsert = true;
+        _upsertKeyField = keyField;
+        return this;
+    }
+
+    public MongoWriter DropCollectionFirst()
+    {
+        _dropCollection = true;
+        return this;
+    }
+
+    public MongoWriter CreateIndex(params string[] fields)
+    {
+        _createIndexes = true;
+        _indexFields.AddRange(fields);
+        return this;
+    }
+
+    public void Write(IEnumerable<DataRow> rows)
+    {
+        var client = new MongoClient(_connectionString);
+        var database = client.GetDatabase(_databaseName);
+        var collection = database.GetCollection<BsonDocument>(_collectionName);
+
+        if (_dropCollection)
+        {
+            database.DropCollection(_collectionName);
+            collection = database.GetCollection<BsonDocument>(_collectionName);
+        }
+
+        if (_createIndexes && _indexFields.Any())
+        {
+            CreateIndexes(collection);
+        }
+
+        var batch = new List<BsonDocument>();
+        var upsertBatch = new List<(FilterDefinition<BsonDocument>, BsonDocument)>();
+
+        foreach (var row in rows)
+        {
+            var document = ConvertToDocument(row);
+
+            if (_upsert)
+            {
+                object filterValue = null;
+                if (row.ContainsColumn(_upsertKeyField))
+                    filterValue = row[_upsertKeyField];
+                
+                if (filterValue != null)
+                {
+                    var filter = Builders<BsonDocument>.Filter.Eq(_upsertKeyField, BsonValue.Create(filterValue));
+                    upsertBatch.Add((filter, document));
+                }
+                else
+                {
+                    batch.Add(document);
+                }
+
+                if (upsertBatch.Count >= _batchSize)
+                {
+                    ProcessUpsertBatch(collection, upsertBatch);
+                    upsertBatch.Clear();
+                }
+            }
+            else
+            {
+                batch.Add(document);
+            }
+
+            if (batch.Count >= _batchSize)
+            {
+                collection.InsertMany(batch, _insertOptions);
+                batch.Clear();
+            }
+        }
+
+        if (batch.Any())
+        {
+            collection.InsertMany(batch, _insertOptions);
+        }
+
+        if (upsertBatch.Any())
+        {
+            ProcessUpsertBatch(collection, upsertBatch);
+        }
+    }
+
+    private void ProcessUpsertBatch(IMongoCollection<BsonDocument> collection, 
+        List<(FilterDefinition<BsonDocument>, BsonDocument)> batch)
+    {
+        var bulkOps = new List<WriteModel<BsonDocument>>();
+        
+        foreach (var (filter, document) in batch)
+        {
+            bulkOps.Add(new ReplaceOneModel<BsonDocument>(filter, document) { IsUpsert = true });
+        }
+
+        if (bulkOps.Any())
+        {
+            collection.BulkWrite(bulkOps, new BulkWriteOptions { IsOrdered = false });
+        }
+    }
+
+    private void CreateIndexes(IMongoCollection<BsonDocument> collection)
+    {
+        var indexKeysDefinitions = new List<CreateIndexModel<BsonDocument>>();
+
+        foreach (var field in _indexFields)
+        {
+            var indexKeys = Builders<BsonDocument>.IndexKeys.Ascending(field);
+            indexKeysDefinitions.Add(new CreateIndexModel<BsonDocument>(indexKeys));
+        }
+
+        if (indexKeysDefinitions.Any())
+        {
+            collection.Indexes.CreateMany(indexKeysDefinitions);
+        }
+    }
+
+    private BsonDocument ConvertToDocument(DataRow row)
+    {
+        var document = new BsonDocument();
+        
+        foreach (var columnName in row.GetColumnNames())
+        {
+            var value = row[columnName];
+            document[columnName] = ConvertToBsonValue(value);
+        }
+        
+        return document;
+    }
+
+    private BsonValue ConvertToBsonValue(object value)
+    {
+        if (value == null)
+            return BsonNull.Value;
+
+        switch (value)
+        {
+            case string s:
+                return new BsonString(s);
+            case int i:
+                return new BsonInt32(i);
+            case long l:
+                return new BsonInt64(l);
+            case double d:
+                return new BsonDouble(d);
+            case decimal dec:
+                return new BsonDecimal128(dec);
+            case float f:
+                return new BsonDouble(f);
+            case bool b:
+                return new BsonBoolean(b);
+            case DateTime dt:
+                return new BsonDateTime(dt);
+            case Guid guid:
+                return new BsonString(guid.ToString());
+            case byte[] bytes:
+                return new BsonBinaryData(bytes);
+            case IEnumerable<object> list:
+                return ConvertListToBsonArray(list);
+            case Dictionary<string, object> dict:
+                return ConvertDictionaryToBsonDocument(dict);
+            default:
+                return BsonValue.Create(value);
+        }
+    }
+
+    private BsonArray ConvertListToBsonArray(IEnumerable<object> list)
+    {
+        var array = new BsonArray();
+        foreach (var item in list)
+        {
+            array.Add(ConvertToBsonValue(item));
+        }
+        return array;
+    }
+
+    private BsonDocument ConvertDictionaryToBsonDocument(Dictionary<string, object> dict)
+    {
+        var document = new BsonDocument();
+        foreach (var kvp in dict)
+        {
+            document[kvp.Key] = ConvertToBsonValue(kvp.Value);
+        }
+        return document;
+    }
+}

--- a/DataFlow.Tests/MongoDbTests.cs
+++ b/DataFlow.Tests/MongoDbTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using DataFlow.Core;
+using DataFlow.Core.MongoDB;
+using MongoDB.Driver;
+
+namespace DataFlow.Tests
+{
+    public class MongoDbTests
+    {
+        [Fact]
+        public void MongoReader_Constructor_ThrowsOnNullConnectionString()
+        {
+            Assert.Throws<ArgumentNullException>(() => 
+                new MongoReader(null, "database", "collection"));
+        }
+
+        [Fact]
+        public void MongoReader_Constructor_ThrowsOnNullDatabase()
+        {
+            Assert.Throws<ArgumentNullException>(() => 
+                new MongoReader("mongodb://localhost", null, "collection"));
+        }
+
+        [Fact]
+        public void MongoReader_Constructor_ThrowsOnNullCollection()
+        {
+            Assert.Throws<ArgumentNullException>(() => 
+                new MongoReader("mongodb://localhost", "database", null));
+        }
+
+        [Fact]
+        public void MongoReader_ValidConstructor_CreatesInstance()
+        {
+            var reader = new MongoReader("mongodb://localhost", "testdb", "users");
+            Assert.NotNull(reader);
+        }
+
+        [Fact]
+        public void MongoReader_ChainedMethods_ReturnsSelf()
+        {
+            var reader = new MongoReader("mongodb://localhost", "testdb", "users");
+            
+            var result = reader
+                .Where("status", "active")
+                .Sort("name")
+                .Limit(10)
+                .Skip(5)
+                .Project("name", "email");
+            
+            Assert.Same(reader, result);
+        }
+
+        [Fact]
+        public void MongoWriter_Constructor_ThrowsOnNullConnectionString()
+        {
+            Assert.Throws<ArgumentNullException>(() => 
+                new MongoWriter(null, "database", "collection"));
+        }
+
+        [Fact]
+        public void MongoWriter_Constructor_ThrowsOnNullDatabase()
+        {
+            Assert.Throws<ArgumentNullException>(() => 
+                new MongoWriter("mongodb://localhost", null, "collection"));
+        }
+
+        [Fact]
+        public void MongoWriter_Constructor_ThrowsOnNullCollection()
+        {
+            Assert.Throws<ArgumentNullException>(() => 
+                new MongoWriter("mongodb://localhost", "database", null));
+        }
+
+        [Fact]
+        public void MongoWriter_ValidConstructor_CreatesInstance()
+        {
+            var writer = new MongoWriter("mongodb://localhost", "testdb", "users");
+            Assert.NotNull(writer);
+        }
+
+        [Fact]
+        public void MongoWriter_ChainedMethods_ReturnsSelf()
+        {
+            var writer = new MongoWriter("mongodb://localhost", "testdb", "users");
+            
+            var result = writer
+                .WithBatchSize(500)
+                .WithUpsert("_id")
+                .CreateIndex("email", "username");
+            
+            Assert.Same(writer, result);
+        }
+
+        [Fact]
+        public void DataFlow_From_MongoDB_CreatesValidPipeline()
+        {
+            var pipeline = DataFlow.Core.DataFlow.From.MongoDB(
+                "mongodb://localhost", "testdb", "users");
+            
+            Assert.NotNull(pipeline);
+            Assert.IsAssignableFrom<IPipeline<DataRow>>(pipeline);
+        }
+
+        [Fact]
+        public void DataFlow_From_MongoDB_WithConfiguration_CreatesValidPipeline()
+        {
+            var pipeline = DataFlow.Core.DataFlow.From.MongoDB(
+                "mongodb://localhost", "testdb", "users",
+                mongo => mongo
+                    .Where("active", true)
+                    .Sort("created", false)
+                    .Limit(100));
+            
+            Assert.NotNull(pipeline);
+            Assert.IsAssignableFrom<IPipeline<DataRow>>(pipeline);
+        }
+
+        [Fact]
+        public void ToMongoDB_ExtensionMethod_Available()
+        {
+            var rows = new List<DataRow>
+            {
+                new DataRow { ["_id"] = 1, ["name"] = "Test User" }
+            };
+            
+            var pipeline = DataFlow.Core.DataFlow.From.Collection(rows);
+            
+            Assert.NotNull(pipeline);
+        }
+
+        [Fact]
+        public void MongoReader_WhereJson_SetsFilter()
+        {
+            var reader = new MongoReader("mongodb://localhost", "testdb", "users");
+            var result = reader.WhereJson("{ 'age': { '$gt': 18 } }");
+            
+            Assert.Same(reader, result);
+        }
+
+        [Fact]
+        public void MongoReader_Aggregate_AddsPipelineStage()
+        {
+            var reader = new MongoReader("mongodb://localhost", "testdb", "users");
+            
+            var result = reader
+                .Aggregate("{ '$match': { 'status': 'active' } }")
+                .Aggregate("{ '$group': { '_id': '$city', 'count': { '$sum': 1 } } }");
+            
+            Assert.Same(reader, result);
+        }
+
+        [Fact]
+        public void MongoWriter_DropCollectionFirst_SetsFlag()
+        {
+            var writer = new MongoWriter("mongodb://localhost", "testdb", "users");
+            var result = writer.DropCollectionFirst();
+            
+            Assert.Same(writer, result);
+        }
+
+        [Fact]
+        public void DataRow_ConversionToMongoDB_HandlesAllTypes()
+        {
+            var row = new DataRow
+            {
+                ["string"] = "text",
+                ["int"] = 42,
+                ["long"] = 42L,
+                ["double"] = 42.5,
+                ["bool"] = true,
+                ["date"] = DateTime.Now,
+                ["null"] = null,
+                ["guid"] = Guid.NewGuid(),
+                ["list"] = new List<object> { 1, 2, 3 },
+                ["dict"] = new Dictionary<string, object> { ["key"] = "value" }
+            };
+            
+            Assert.Equal(10, row.GetColumnNames().Count());
+        }
+
+        [Fact]
+        public void MongoDbPipeline_FilterAndTransform_WorksCorrectly()
+        {
+            var testData = new List<DataRow>
+            {
+                new DataRow { ["_id"] = 1, ["name"] = "Alice", ["age"] = 25, ["city"] = "NYC" },
+                new DataRow { ["_id"] = 2, ["name"] = "Bob", ["age"] = 30, ["city"] = "LA" },
+                new DataRow { ["_id"] = 3, ["name"] = "Charlie", ["age"] = 35, ["city"] = "NYC" }
+            };
+            
+            var result = DataFlow.Core.DataFlow.From.Collection(testData)
+                .Filter(r => r["city"].ToString() == "NYC")
+                .Map(r => new DataRow 
+                { 
+                    ["_id"] = r["_id"],
+                    ["name"] = r["name"],
+                    ["ageGroup"] = (int)r["age"] > 30 ? "Senior" : "Junior"
+                })
+                .ToList();
+            
+            Assert.Equal(2, result.Count);
+            Assert.Equal("Junior", result[0]["ageGroup"]);
+            Assert.Equal("Senior", result[1]["ageGroup"]);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds comprehensive MongoDB support to DataFlow, enabling seamless integration with MongoDB databases for ETL operations.
### API Methods
- `DataFlow.From.MongoDB(connectionString, database, collection)`
- `.ToMongoDB(connectionString, database, collection)`
- Configuration options via fluent API
- 
## Usage Example

```csharp
// Read from MongoDB
DataFlow.From.MongoDB("mongodb://localhost", "store", "products", mongo => mongo
    .Where("category", "Electronics")
    .Sort("price", ascending: false)
    .Limit(100))
    .ToCsv("products.csv");

// Write to MongoDB with upsert
DataFlow.From.Csv("updates.csv")
    .ToMongoDB("mongodb://localhost", "store", "products", writer => writer
        .WithUpsert("sku")
        .WithBatchSize(500));
```
