### PR TITLE
Add ApiReader with generic type and expose ReadAsync

### DIFF
--- a/PipeFlow.Tests/ApiReaderGenericTests.cs
+++ b/PipeFlow.Tests/ApiReaderGenericTests.cs
@@ -1,0 +1,288 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using PipeFlow.Core.Api;
+
+namespace PipeFlow.Tests
+{
+    public class ApiReaderGenericTests
+    {
+        private sealed class SampleDto
+        {
+            public int Id { get; set; }
+            public string? Name { get; set; }
+        }
+
+        private sealed class TestableApiReader<T> : ApiReader<T>
+        {
+            public TestableApiReader(string baseUrl) : base(baseUrl)
+            {
+            }
+
+            public string? AuthTokenValue => AuthToken;
+            public IReadOnlyDictionary<string, string> HeaderValues => Headers;
+            public int MaxRetriesValue => MaxRetries;
+            public TimeSpan RetryDelayValue => RetryDelay;
+
+            public Func<string, Task<T>>? CustomFetch { get; set; }
+
+            public void UseHttpClient(HttpClient client)
+            {
+                var field = typeof(ApiReader<T>).GetField("HttpClient", BindingFlags.Instance | BindingFlags.NonPublic);
+                field?.SetValue(this, client);
+            }
+
+            protected override Task<T> FetchDataWithRetry(string url)
+            {
+                if (CustomFetch != null)
+                {
+                    return CustomFetch(url);
+                }
+
+                return base.FetchDataWithRetry(url);
+            }
+        }
+
+        private sealed class TestHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responses;
+
+            public TestHttpMessageHandler(IEnumerable<Func<HttpRequestMessage, HttpResponseMessage>> responses)
+            {
+                _responses = new Queue<Func<HttpRequestMessage, HttpResponseMessage>>(responses);
+            }
+
+            public List<HttpRequestMessage> Requests { get; } = new();
+
+            public void EnqueueResponse(Func<HttpRequestMessage, HttpResponseMessage> response)
+            {
+                _responses.Enqueue(response);
+            }
+
+            public void EnqueueResponses(params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
+            {
+                foreach (var response in responses)
+                {
+                    _responses.Enqueue(response);
+                }
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Requests.Add(CloneRequest(request));
+
+                var responseFactory = _responses.Count > 0
+                    ? _responses.Dequeue()
+                    : (_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+                var response = responseFactory(request);
+                return Task.FromResult(response);
+            }
+
+            private static HttpRequestMessage CloneRequest(HttpRequestMessage request)
+            {
+                var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+
+                foreach (var header in request.Headers)
+                {
+                    clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+
+                return clone;
+            }
+        }
+
+        [Fact]
+        public void Constructor_NullUrl_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ApiReader<SampleDto>(null!));
+        }
+
+        [Fact]
+        public async Task ReadAsync_ReturnsDeserializedResult()
+        {
+            var reader = CreateReader(out var handler);
+
+            handler.EnqueueResponses(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new SampleDto { Id = 42, Name = "Test" })
+            });
+
+            var result = await reader.ReadAsync();
+
+            Assert.NotNull(result);
+            Assert.Equal(42, result!.Id);
+            Assert.Equal("Test", result.Name);
+        }
+
+        [Fact]
+        public void Read_UsesSynchronousWrapper()
+        {
+            var reader = new TestableApiReader<SampleDto>("https://api.example.com/data")
+            {
+                CustomFetch = _ => Task.FromResult(new SampleDto { Id = 7, Name = "Sync" })
+            };
+
+            var result = reader.Read();
+
+            Assert.Equal(7, result.Id);
+            Assert.Equal("Sync", result.Name);
+        }
+
+        [Fact]
+        public async Task WithAuth_AddsAuthorizationHeader()
+        {
+            var reader = CreateReader(out var handler);
+
+            handler.EnqueueResponses(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new SampleDto())
+            });
+
+            reader.WithAuth("token-value", "Bearer");
+
+            await reader.ReadAsync();
+
+            var authorization = handler.Requests.Single().Headers.GetValues("Authorization").Single();
+            Assert.Equal("Bearer token-value", authorization);
+            Assert.Equal("Bearer token-value", reader.AuthTokenValue);
+        }
+
+        [Fact]
+        public async Task WithHeader_AddsCustomHeader()
+        {
+            var reader = CreateReader(out var handler);
+
+            handler.EnqueueResponses(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new SampleDto())
+            });
+
+            reader.WithHeader("X-Custom", "Value123");
+
+            await reader.ReadAsync();
+
+            var headerValues = handler.Requests.Single().Headers.GetValues("X-Custom").ToArray();
+            Assert.Single(headerValues);
+            Assert.Equal("Value123", headerValues[0]);
+            Assert.Equal("Value123", reader.HeaderValues["X-Custom"]);
+        }
+
+        [Fact]
+        public void WithRetry_OverridesRetryConfiguration()
+        {
+            var reader = new TestableApiReader<SampleDto>("https://api.example.com/data");
+
+            reader.WithRetry(5, TimeSpan.FromMilliseconds(250));
+
+            Assert.Equal(5, reader.MaxRetriesValue);
+            Assert.Equal(TimeSpan.FromMilliseconds(250), reader.RetryDelayValue);
+        }
+
+        [Fact]
+        public async Task FetchDataWithRetry_RetriesUntilSuccess()
+        {
+            var reader = CreateReader(out var handler);
+
+            reader.WithRetry(3, TimeSpan.Zero);
+
+            handler.EnqueueResponses(
+                _ => new HttpResponseMessage(HttpStatusCode.InternalServerError),
+                _ => new HttpResponseMessage(HttpStatusCode.BadGateway),
+                _ => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new SampleDto { Id = 1 })
+                });
+
+            var result = await reader.ReadAsync();
+
+            Assert.Equal(3, handler.Requests.Count);
+            Assert.NotNull(result);
+            Assert.Equal(1, result!.Id);
+        }
+
+        [Fact]
+        public async Task FetchDataWithRetry_ReturnsDefaultAfterUnsuccessfulResponses()
+        {
+            var reader = CreateReader(out var handler);
+
+            reader.WithRetry(2, TimeSpan.Zero);
+
+            handler.EnqueueResponses(
+                _ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+                _ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+            var result = await reader.ReadAsync();
+
+            Assert.Equal(2, handler.Requests.Count);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task FetchDataWithRetry_ThrowsAfterMaxExceptions()
+        {
+            var reader = CreateReader(out var handler);
+
+            reader.WithRetry(2, TimeSpan.Zero);
+
+            handler.EnqueueResponses(
+                _ => throw new HttpRequestException("boom"),
+                _ => throw new HttpRequestException("boom"));
+
+            var exception = await Assert.ThrowsAsync<Exception>(() => reader.ReadAsync());
+
+            Assert.Contains("Failed to fetch data", exception.Message);
+            Assert.Equal(2, handler.Requests.Count);
+        }
+
+        [Fact]
+        public async Task FetchDataWithRetry_NoConfiguredResponses_ReturnsDefault()
+        {
+            var reader = CreateReader(out var handler);
+
+            var result = await reader.ReadAsync();
+
+            Assert.Null(result);
+            Assert.Equal(reader.MaxRetriesValue, handler.Requests.Count);
+        }
+
+        [Fact]
+        public void WithHeader_RewritesExistingValue()
+        {
+            var reader = CreateReader(out _);
+
+            reader.WithHeader("X-Duplicate", "First")
+                  .WithHeader("X-Duplicate", "Second");
+
+            Assert.Equal("Second", reader.HeaderValues["X-Duplicate"]);
+        }
+
+        [Fact]
+        public async Task Dispose_PreventsFurtherRequests()
+        {
+            var reader = CreateReader(out var handler);
+
+            handler.EnqueueResponses(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new SampleDto())
+            });
+
+            await reader.ReadAsync();
+
+            reader.Dispose();
+
+            var exception = await Assert.ThrowsAsync<Exception>(() => reader.ReadAsync());
+
+            Assert.Contains("Failed to fetch data", exception.Message);
+            Assert.All(handler.Requests, request => Assert.Equal(HttpMethod.Get, request.Method));
+        }
+
+        private static TestableApiReader<SampleDto> CreateReader(out TestHttpMessageHandler handler)
+        {
+            handler = new TestHttpMessageHandler(Array.Empty<Func<HttpRequestMessage, HttpResponseMessage>>());
+            var reader = new TestableApiReader<SampleDto>("https://api.example.com/data");
+            reader.UseHttpClient(new HttpClient(handler));
+            return reader;
+        }
+    }
+}

--- a/PipeFlow/Api/ApiReaderGeneric.cs
+++ b/PipeFlow/Api/ApiReaderGeneric.cs
@@ -1,0 +1,107 @@
+using System.Net.Http.Json;
+
+namespace PipeFlow.Core.Api;
+
+public class ApiReader<TResult> : IDisposable
+{
+    protected readonly string BaseUrl;
+    protected readonly HttpClient HttpClient;
+    protected string AuthToken;
+    protected readonly Dictionary<string, string> Headers;
+    protected int MaxRetries = 3;
+    protected TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
+
+    public ApiReader(string baseUrl)
+    {
+        BaseUrl = baseUrl ?? throw new ArgumentNullException(nameof(baseUrl));
+        HttpClient = new HttpClient();
+        Headers = new Dictionary<string, string>();
+    }
+
+    public virtual ApiReader<TResult> WithAuth(string token, string scheme = "Bearer")
+    {
+        AuthToken = $"{scheme} {token}";
+        return this;
+    }
+
+    public virtual ApiReader<TResult> WithHeader(string name, string value)
+    {
+        Headers[name] = value;
+        return this;
+    }
+
+    public virtual ApiReader<TResult> WithRetry(int maxRetries, TimeSpan? delay = null)
+    {
+        MaxRetries = maxRetries;
+        if (delay != null)
+            RetryDelay = delay.Value;
+        return this;
+    }
+
+    public virtual TResult Read()
+    {
+        var task = Task.Run(async () => await ReadAsync());
+        task.Wait();
+
+        return task.Result;
+    }
+
+    public virtual async Task<TResult> ReadAsync()
+    {
+        return await FetchDataWithRetry(BaseUrl);
+    }
+
+    protected virtual async Task<TResult> FetchDataWithRetry(string url)
+    {
+        var attempt = 0;
+
+        while (attempt < MaxRetries)
+        {
+            try
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+                if (AuthToken != null)
+                {
+                    request.Headers.Add("Authorization", AuthToken);
+                }
+
+                foreach (var header in Headers)
+                {
+                    request.Headers.Add(header.Key, header.Value);
+                }
+
+                var response = await HttpClient.SendAsync(request);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return await response.Content.ReadFromJsonAsync<TResult>();
+                }
+
+                attempt++;
+                if (attempt < MaxRetries)
+                {
+                    await Task.Delay(RetryDelay * attempt);
+                }
+            }
+            catch (Exception ex)
+            {
+                attempt++;
+                if (attempt >= MaxRetries)
+                {
+                    throw new Exception($"Failed to fetch data from {url} after {MaxRetries} attempts", ex);
+                }
+
+                await Task.Delay(RetryDelay * attempt);
+            }
+        }
+
+        return default;
+    }
+
+    public void Dispose()
+    {
+        HttpClient?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/PipeFlow/Api/ApiReaderGeneric.cs
+++ b/PipeFlow/Api/ApiReaderGeneric.cs
@@ -15,23 +15,41 @@ public class ApiReader<TResult> : IDisposable
     {
         BaseUrl = baseUrl ?? throw new ArgumentNullException(nameof(baseUrl));
         HttpClient = new HttpClient();
-        Headers = new Dictionary<string, string>();
+        Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     }
 
     public virtual ApiReader<TResult> WithAuth(string token, string scheme = "Bearer")
     {
+        if (string.IsNullOrWhiteSpace(token))
+            throw new ArgumentException("Authentication token cannot be null or whitespace.", nameof(token));
+
+        if (string.IsNullOrWhiteSpace(scheme))
+            throw new ArgumentException("Authentication scheme cannot be null or whitespace.", nameof(scheme));
+
         AuthToken = $"{scheme} {token}";
         return this;
     }
 
     public virtual ApiReader<TResult> WithHeader(string name, string value)
     {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Header name cannot be null or whitespace.", nameof(name));
+
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
         Headers[name] = value;
         return this;
     }
 
     public virtual ApiReader<TResult> WithRetry(int maxRetries, TimeSpan? delay = null)
     {
+        if (maxRetries <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxRetries), maxRetries, "Retry count must be greater than zero.");
+
+        if (delay is { } retryDelay && retryDelay < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(delay), delay, "Retry delay must be non-negative.");
+
         MaxRetries = maxRetries;
         if (delay != null)
             RetryDelay = delay.Value;
@@ -40,10 +58,9 @@ public class ApiReader<TResult> : IDisposable
 
     public virtual TResult Read()
     {
-        var task = Task.Run(async () => await ReadAsync());
-        task.Wait();
+        var result = ReadAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-        return task.Result;
+        return result;
     }
 
     public virtual async Task<TResult> ReadAsync()
@@ -59,29 +76,15 @@ public class ApiReader<TResult> : IDisposable
         {
             try
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, url);
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                ApplyRequestHeaders(request);
 
-                if (AuthToken != null)
-                {
-                    request.Headers.Add("Authorization", AuthToken);
-                }
-
-                foreach (var header in Headers)
-                {
-                    request.Headers.Add(header.Key, header.Value);
-                }
-
-                var response = await HttpClient.SendAsync(request);
+                using var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
                 if (response.IsSuccessStatusCode)
                 {
-                    return await response.Content.ReadFromJsonAsync<TResult>();
-                }
-
-                attempt++;
-                if (attempt < MaxRetries)
-                {
-                    await Task.Delay(RetryDelay * attempt);
+                    var result = await response.Content.ReadFromJsonAsync<TResult>();
+                    return result;
                 }
             }
             catch (Exception ex)
@@ -93,6 +96,13 @@ public class ApiReader<TResult> : IDisposable
                 }
 
                 await Task.Delay(RetryDelay * attempt);
+                continue;
+            }
+
+            attempt++;
+            if (attempt < MaxRetries)
+            {
+                await Task.Delay(RetryDelay * attempt);
             }
         }
 
@@ -103,5 +113,21 @@ public class ApiReader<TResult> : IDisposable
     {
         HttpClient?.Dispose();
         GC.SuppressFinalize(this);
+    }
+
+    private void ApplyRequestHeaders(HttpRequestMessage request)
+    {
+        if (!string.IsNullOrWhiteSpace(AuthToken))
+        {
+            request.Headers.Add("Authorization", AuthToken);
+        }
+
+        foreach (var header in Headers)
+        {
+            if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+            {
+                throw new InvalidOperationException($"Failed to add header '{header.Key}' to the request.");
+            }
+        }
     }
 }

--- a/PipeFlow/PipeFlow.cs
+++ b/PipeFlow/PipeFlow.cs
@@ -115,6 +115,20 @@ public static class PipeFlow
         configure?.Invoke(reader);
         return new Pipeline<DataRow>(reader.Read());
     }
+    
+    public IPipeline<TResult> Api<TResult>(string url, Action<ApiReader<TResult>>? configure = null)
+    {
+        var reader = new ApiReader<TResult>(url);
+        configure?.Invoke(reader);
+        return new Pipeline<TResult>([reader.Read()]);
+    }
+    
+    public async Task<IPipeline<TResult>> ApiAsync<TResult>(string url, Action<ApiReader<TResult>>? configure = null)
+    {
+        var reader = new ApiReader<TResult>(url);
+        configure?.Invoke(reader);
+        return new Pipeline<TResult>([await reader.ReadAsync()]);
+    }
 
     public IPipeline<DataRow> MongoDB(string connectionString, string database, string collection)
     {


### PR DESCRIPTION
## Overview

- Introduce a reusable `ApiReader<TResult>` that centralises auth/header/retry logic and returns strongly typed responses.
- Retool the existing `ApiReader` to inherit from the generic base so `DataRow` pagination + JSON parsing still work.
- Extend `PipeFlow.From.Api` with typed and async entry points, and add a matching unit-test suite covering the new reader’s behaviours.

## Key Changes

- `PipeFlow/Api/ApiReaderGeneric.cs`: new generic reader with typed Read/ReadAsync, HTTP retry logic, auth/header configuration, and IDisposable support.
- `PipeFlow/Api/ApiReader.cs`: now sealed and derived from the generic reader; keeps pagination, JSON parsing into `DataRow`, and overrides `FetchDataWithRetry`.
- `PipeFlow/PipeFlow.cs`: adds `Api<TResult>` and `ApiAsync<TResult>` helpers so pipelines can consume strongly typed DTOs or await the async fetch path.
- `PipeFlow.Tests/ApiReaderGenericTests.cs`: covers deserialization, sync wrapper, auth/headers, retry success/failure/default paths, header overwrites, and disposal – ensuring the generic reader is fully exercised.

## Why It Matters

- Consumers can hydrate custom DTOs directly without post-processing `DataRow` dictionaries.
- Shared HTTP concerns (auth, headers, retries) live in one place, simplifying future features.
- Async pipeline support avoids synchronous blocking when fetching from APIs.
- Dedicated tests provide confidence that the generic reader handles happy-path and failure scenarios. 